### PR TITLE
Fix Results Post when the Elapsed time is in milliseconds

### DIFF
--- a/src/Extension.php
+++ b/src/Extension.php
@@ -148,6 +148,12 @@ class Extension extends CodeceptionExtension
                 }
             );
 
+            foreach ($results as &$result) {
+                if($result['elapsed'] === '0s') {
+                    $result['elapsed'] = '1s';
+                }
+            }
+            
             $run = $entry->runs[0];
             $conn->execute(
                 '/add_results_for_cases/'. $run->id,


### PR DESCRIPTION
So Testrail API does not support millisecond in elapsed status time. 

[LINK](https://discuss.gurock.com/t/elapsed-field-datatype-api-question/1089/16):
> Hello David,
> Thanks for your feedback! The elapsed/estimate (timespan) fields currently have a minimum value of one second so we would recommend rounding your timespan values to the nearest second. Storing this in a structured format instead of a simple string has many advantages and allows TestRail to calculate estimates....

When you try to submit with 0s as elapsed time you get :
`Error 400: "error": "Field :elapsed is not in a valid time span format."`

The fix rounds it up to 1 second before posting the results. 